### PR TITLE
Add a JDK-19 image

### DIFF
--- a/.github/workflows/jdk-19.yml
+++ b/.github/workflows/jdk-19.yml
@@ -1,4 +1,4 @@
-name: jdk-18
+name: jdk-19
 
 on:
   push:

--- a/.github/workflows/jdk-19.yml
+++ b/.github/workflows/jdk-19.yml
@@ -3,7 +3,7 @@ name: jdk-18
 on:
   push:
     branches: [ main ]
-    paths: [ 'jdk-18/**' ]
+    paths: [ 'jdk-19/**' ]
   workflow_dispatch:
 
 jobs:
@@ -23,6 +23,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: ./jdk-18
-          tags: markhobson/maven-chrome:jdk-18
+          context: ./jdk-19
+          tags: markhobson/maven-chrome:jdk-19,markhobson/maven-chrome:latest
           push: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image for Java automated UI tests.
 
 Includes:
 
-* JDK 8/11/17/18
+* JDK 8/11/17/18/19
 * Maven 3.8.6
 * Chrome 108.0.5359.98
 * ChromeDriver 108.0.5359.71
@@ -18,7 +18,8 @@ The following Docker tags are available:
 * `jdk-8` [(jdk-8/Dockerfile)](jdk-8/Dockerfile)
 * `jdk-11` [(jdk-11/Dockerfile)](jdk-11/Dockerfile)
 * `jdk-17` [(jdk-17/Dockerfile)](jdk-17/Dockerfile)
-* `jdk-18`, `latest` [(jdk-18/Dockerfile)](jdk-18/Dockerfile)
+* `jdk-18` [(jdk-18/Dockerfile)](jdk-18/Dockerfile)
+* `jdk-19`, `latest` [(jdk-19/Dockerfile)](jdk-19/Dockerfile)
 
 ## Demo
 

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,5 @@
 docker build --pull -t maven-chrome:jdk-8 jdk-8 \
 	&& docker build --pull -t maven-chrome:jdk-11 jdk-11 \
 	&& docker build --pull -t maven-chrome:jdk-17 jdk-17 \
-	&& docker build --pull -t maven-chrome:jdk-18 -t maven-chrome jdk-18
+	&& docker build --pull -t maven-chrome:jdk-18 jdk-18 \
+  && docker build --pull -t maven-chrome:jdk-19 -t maven-chrome jdk-19

--- a/jdk-19/Dockerfile
+++ b/jdk-19/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3.8.7-eclipse-temurin-19
+
+# Google Chrome
+
+ARG CHROME_VERSION=108.0.5359.98-1
+ADD google-chrome.repo /etc/yum.repos.d/google-chrome.repo
+RUN microdnf install -y google-chrome-stable-$CHROME_VERSION \
+	&& sed -i 's/"$HERE\/chrome"/"$HERE\/chrome" --no-sandbox/g' /opt/google/chrome/google-chrome
+
+# ChromeDriver
+
+ARG CHROME_DRIVER_VERSION=108.0.5359.71
+RUN microdnf install -y unzip \
+	&& curl -s -o /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+	&& unzip /tmp/chromedriver.zip -d /opt \
+	&& rm /tmp/chromedriver.zip \
+	&& mv /opt/chromedriver /opt/chromedriver-$CHROME_DRIVER_VERSION \
+	&& chmod 755 /opt/chromedriver-$CHROME_DRIVER_VERSION \
+	&& ln -s /opt/chromedriver-$CHROME_DRIVER_VERSION /usr/bin/chromedriver

--- a/jdk-19/google-chrome.repo
+++ b/jdk-19/google-chrome.repo
@@ -1,0 +1,6 @@
+[google-chrome]
+name=google-chrome
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://dl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
This pull request adds an image for JDK-19, based on the `maven:3.8.7-eclipse-temurin-19` image from Dockerhub.

I did not check for the other images, whether they should or can be upgraded to the latest Maven version.  Neither did I check for updates on Chrome or the Chromedriver.  IMHO those steps should be part of separate pull requests.