### PR TITLE
Update Dockerfile

### DIFF
--- a/jdk-17/Dockerfile
+++ b/jdk-17/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.9.5-eclipse-temurin-17
 
 # Google Chrome
 
-ARG CHROME_VERSION=119.0.6045.159-1
+ARG CHROME_VERSION=120.0.6099.109
 RUN apt-get update -qqy \
 	&& apt-get -qqy install gpg unzip \
 	&& wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -15,7 +15,7 @@ RUN apt-get update -qqy \
 
 # ChromeDriver
 
-ARG CHROME_DRIVER_VERSION=119.0.6045.105
+ARG CHROME_DRIVER_VERSION=120.0.6099.109
 RUN wget -q -O /tmp/chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROME_DRIVER_VERSION/linux64/chromedriver-linux64.zip \
 	&& unzip /tmp/chromedriver.zip -d /opt \
 	&& rm /tmp/chromedriver.zip \


### PR DESCRIPTION
Chromedriver no longer reachable from google api updated to latest stable version + chrome version.